### PR TITLE
Require active_support in RedcarpetHTML#slug

### DIFF
--- a/lib/livingstyleguide/markdown_extensions.rb
+++ b/lib/livingstyleguide/markdown_extensions.rb
@@ -69,6 +69,7 @@ module LivingStyleGuide
     private
 
     def slug(text)
+      require "active_support"
       require "active_support/core_ext/string/inflections"
       if ::ActiveSupport::VERSION::MAJOR >= 5
         ::ActiveSupport::Inflector.parameterize(text, separator: "-")


### PR DESCRIPTION
In addition to requiring require "active_support/core_ext/string/inflections", it's also necessary to require the base "active_support". See https://github.com/livingstyleguide/livingstyleguide/issues/219 for details.